### PR TITLE
Configuración de Spring Security básica y CORS global

### DIFF
--- a/src/main/java/com/platzi/pizzeria_presto/web/configuracion/CrossConfig.java
+++ b/src/main/java/com/platzi/pizzeria_presto/web/configuracion/CrossConfig.java
@@ -1,0 +1,24 @@
+package com.platzi.pizzeria_presto.web.configuracion;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.Arrays;
+
+@Configuration
+public class CrossConfig {
+    @Bean
+    CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:4200"));
+        corsConfiguration.setAllowedMethods(Arrays.asList("GET", "PUT", "POST", "DELETE"));
+        corsConfiguration.setAllowedHeaders(Arrays.asList("*")); //permite todos los encabezados que vengan a través de CORS
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/platzi/pizzeria_presto/web/configuracion/SecurityConfig.java
+++ b/src/main/java/com/platzi/pizzeria_presto/web/configuracion/SecurityConfig.java
@@ -13,11 +13,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest()
                         .authenticated() // Proteger todas las demás rutas
                 )
-                .httpBasic(httpBasic -> {}); // Habilita autenticación básica
+            .httpBasic(httpBasic -> {}); // Habilita autenticación básica
         return http.build();
     }
 }

--- a/src/main/java/com/platzi/pizzeria_presto/web/controlador/PizzaController.java
+++ b/src/main/java/com/platzi/pizzeria_presto/web/controlador/PizzaController.java
@@ -94,6 +94,7 @@ public class PizzaController {
             }
     )
     @GetMapping("/available/{estado}")
+    // @CrossOrigin(origins = "http://localhost:4200")
     public ResponseEntity<List<Pizza>> getPizzaAvailable(@PathVariable String estado){
         return this.pizzaServicio.getAllByAvailable(estado)
                 .map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());


### PR DESCRIPTION
Configuración de Spring Security básica, deshabilitando CSRF y aplicando una configuración de CORS global para permitir peticiones de un origen, métodos y headers determinados.